### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Run tests
+on: [push]
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: pip install . pytest
+
+      - name: Install graphviz
+        run: sudo apt-get install --no-install-recommends graphviz
+
+      - name: Run tests
+        run: py.test

--- a/test_docs/example.diagrams.py
+++ b/test_docs/example.diagrams.py
@@ -1,0 +1,29 @@
+from diagrams import Cluster, Diagram
+from diagrams.aws.compute import ECS, EKS, Lambda
+from diagrams.aws.database import Redshift
+from diagrams.aws.integration import SQS
+from diagrams.aws.storage import S3
+
+
+with Diagram("Event Processing", show=False):
+    source = EKS("k8s source")
+
+    with Cluster("Event Flows"):
+        with Cluster("Event Workers"):
+            workers = [ECS("worker1"),
+                       ECS("worker2"),
+                       ECS("worker3")]
+
+        queue = SQS("event queue")
+
+        with Cluster("Processing"):
+            handlers = [Lambda("proc1"),
+                        Lambda("proc2"),
+                        Lambda("proc3")]
+
+    store = S3("events store")
+    dw = Redshift("analytics")
+
+    source >> workers >> queue >> handlers
+    handlers >> store
+    handlers >> dw

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,33 @@
+import shutil
+import subprocess
+import os
+
+MKDOCS_CONFIG = """
+site_name: mkdocs-diagrams
+docs_dir: docs
+
+plugins:
+  - diagrams
+"""
+
+
+def file_contents(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def test_build(tmp_path):
+    with open(tmp_path / "mkdocs.yml", "w") as f:
+        f.write(MKDOCS_CONFIG)
+    shutil.copytree("test_docs", tmp_path / "docs")
+    shutil.copy("README.md", tmp_path / "docs" / "README.md")
+
+    subprocess.run(
+        ["mkdocs", "build", "--verbose", "--strict", "--site-dir", tmp_path / "site"],
+        check=True,
+        cwd=tmp_path
+    )
+
+    index_html = file_contents(tmp_path / "site" / "index.html")
+    assert "mkdocs-diagrams" in index_html
+    assert os.path.exists(tmp_path / "site" / "event_processing.png")


### PR DESCRIPTION
Add an integration test to verify diagrams are being rendered when mkdocs is run with this plugin enabled and set these up to be run from GitHub Actions CI.